### PR TITLE
Gingerbread

### DIFF
--- a/common.h
+++ b/common.h
@@ -101,6 +101,12 @@ void ui_reset_progress();
 #define STRINGIFY(x) #x
 #define EXPAND(x) STRINGIFY(x)
 
+// basic bitvector utils
+#define IS_SET(flag,bit)  ((flag) & (bit))
+#define SET_BIT(var,bit)  ((var) |= (bit))
+#define REMOVE_BIT(var,bit)  ((var) &= ~(bit))
+#define TOGGLE_BIT(var,bit) ((var) ^= (bit))
+
 typedef struct {
     const char* mount_point;  // eg. "/cache".  must live in the root directory.
 

--- a/edifyscripting.c
+++ b/edifyscripting.c
@@ -169,26 +169,22 @@ Value* RestoreFn(const char* name, State* state, int argc, Expr* argv[]) {
     args2[argc] = NULL;
     
     char* path = strdup(args2[0]);
-    int restoreboot = 1;
-    int restoresystem = 1;
-    int restoredata = 1;
-    int restorecache = 1;
-    int restoresdext = 1;
+    char restore_flags = (RESTORE_BOOT | RESTORE_SYSTEM | RESTORE_DATA | RESTORE_CACHE | RESTORE_SDEXT);
     int i;
     for (i = 1; i < argc; i++)
     {
         if (args2[i] == NULL)
             continue;
         if (strcmp(args2[i], "noboot") == 0)
-            restoreboot = 0;
+            REMOVE_BIT(restore_flags, RESTORE_BOOT);
         else if (strcmp(args2[i], "nosystem") == 0)
-            restoresystem = 0;
+            REMOVE_BIT(restore_flags, RESTORE_SYSTEM);
         else if (strcmp(args2[i], "nodata") == 0)
-            restoredata = 0;
+            REMOVE_BIT(restore_flags, RESTORE_DATA);
         else if (strcmp(args2[i], "nocache") == 0)
-            restorecache = 0;
+            REMOVE_BIT(restore_flags, RESTORE_CACHE);
         else if (strcmp(args2[i], "nosd-ext") == 0)
-            restoresdext = 0;
+            REMOVE_BIT(restore_flags, RESTORE_SDEXT);
     }
     
     for (i = 0; i < argc; ++i) {
@@ -197,7 +193,7 @@ Value* RestoreFn(const char* name, State* state, int argc, Expr* argv[]) {
     free(args);
     free(args2);
 
-    if (0 != nandroid_restore(path, restoreboot, restoresystem, restoredata, restorecache, restoresdext, 0)) {
+    if (0 != nandroid_restore(path, restore_flags)) {
         free(path);
         return StringValue(strdup(""));
     }

--- a/extendedcommands.c
+++ b/extendedcommands.c
@@ -337,7 +337,7 @@ void show_nandroid_restore_menu()
         return;
 
     if (confirm_selection("Confirm restore?", "Yes - Restore"))
-        nandroid_restore(file, 1, 1, 1, 1, 1, 0);
+        nandroid_restore(file, RESTORE_BOOT | RESTORE_DATA | RESTORE_CACHE | RESTORE_SDEXT);
 }
 
 void show_mount_usb_storage_menu()
@@ -713,27 +713,27 @@ void show_nandroid_advanced_restore_menu()
     {
         case 0:
             if (confirm_selection(confirm_restore, "Yes - Restore boot"))
-                nandroid_restore(file, 1, 0, 0, 0, 0, 0);
+                nandroid_restore(file, RESTORE_BOOT);
             break;
         case 1:
             if (confirm_selection(confirm_restore, "Yes - Restore system"))
-                nandroid_restore(file, 0, 1, 0, 0, 0, 0);
+                nandroid_restore(file, RESTORE_SYSTEM);
             break;
         case 2:
             if (confirm_selection(confirm_restore, "Yes - Restore data"))
-                nandroid_restore(file, 0, 0, 1, 0, 0, 0);
+                nandroid_restore(file, RESTORE_DATA);
             break;
         case 3:
             if (confirm_selection(confirm_restore, "Yes - Restore cache"))
-                nandroid_restore(file, 0, 0, 0, 1, 0, 0);
+                nandroid_restore(file, RESTORE_CACHE);
             break;
         case 4:
             if (confirm_selection(confirm_restore, "Yes - Restore sd-ext"))
-                nandroid_restore(file, 0, 0, 0, 0, 1, 0);
+                nandroid_restore(file, RESTORE_SDEXT);
             break;
         case 5:
             if (confirm_selection(confirm_restore, "Yes - Restore wimax"))
-                nandroid_restore(file, 0, 0, 0, 0, 0, 1);
+                nandroid_restore(file, RESTORE_WIMAX);
             break;
     }
 }
@@ -1055,7 +1055,7 @@ void process_volumes() {
     ui_print("in case of error.\n");
 
     nandroid_backup(backup_path);
-    nandroid_restore(backup_path, 1, 1, 1, 1, 1, 0);
+    nandroid_restore(backup_path, RESTORE_BOOT | RESTORE_DATA | RESTORE_CACHE | RESTORE_SDEXT);
     ui_set_show_text(0);
 }
 

--- a/nandroid.c
+++ b/nandroid.c
@@ -299,7 +299,7 @@ int nandroid_restore_partition(const char* backup_path, const char* root) {
     return nandroid_restore_partition_extended(backup_path, root, 1);
 }
 
-int nandroid_restore(const char* backup_path, int restore_boot, int restore_system, int restore_data, int restore_cache, int restore_sdext, int restore_wimax)
+int nandroid_restore(const char* backup_path, char restore_flags)
 {
     ui_set_background(BACKGROUND_ICON_INSTALLING);
     ui_show_indeterminate_progress();
@@ -317,10 +317,10 @@ int nandroid_restore(const char* backup_path, int restore_boot, int restore_syst
     
     int ret;
 
-    if (restore_boot && NULL != volume_for_path("/boot") && 0 != (ret = nandroid_restore_partition(backup_path, "/boot")))
+    if (IS_SET(restore_flags, RESTORE_BOOT) && NULL != volume_for_path("/boot") && 0 != (ret = nandroid_restore_partition(backup_path, "/boot")))
         return ret;
     
-    if (restore_wimax && 0 == (ret = get_partition_device("wimax", tmp)))
+    if (IS_SET(restore_flags, RESTORE_WIMAX) && 0 == (ret = get_partition_device("wimax", tmp)))
     {
         char serialno[PROPERTY_VALUE_MAX];
         
@@ -347,24 +347,24 @@ int nandroid_restore(const char* backup_path, int restore_boot, int restore_syst
         }
     }
 
-    if (restore_system && 0 != (ret = nandroid_restore_partition(backup_path, "/system")))
+    if (IS_SET(restore_flags, RESTORE_SYSTEM) && 0 != (ret = nandroid_restore_partition(backup_path, "/system")))
         return ret;
 
-    if (restore_data && 0 != (ret = nandroid_restore_partition(backup_path, "/data")))
+    if (IS_SET(restore_flags, RESTORE_DATA) && 0 != (ret = nandroid_restore_partition(backup_path, "/data")))
         return ret;
         
     if (has_datadata()) {
-        if (restore_data && 0 != (ret = nandroid_restore_partition(backup_path, "/datadata")))
+        if (IS_SET(restore_flags, RESTORE_DATA) && 0 != (ret = nandroid_restore_partition(backup_path, "/datadata")))
             return ret;
     }
 
-    if (restore_data && 0 != (ret = nandroid_restore_partition_extended(backup_path, "/sdcard/.android_secure", 0)))
+    if (IS_SET(restore_flags, RESTORE_DATA) && 0 != (ret = nandroid_restore_partition_extended(backup_path, "/sdcard/.android_secure", 0)))
         return ret;
 
-    if (restore_cache && 0 != (ret = nandroid_restore_partition_extended(backup_path, "/cache", 0)))
+    if (IS_SET(restore_flags, RESTORE_CACHE) && 0 != (ret = nandroid_restore_partition_extended(backup_path, "/cache", 0)))
         return ret;
 
-    if (restore_sdext && 0 != (ret = nandroid_restore_partition(backup_path, "/sd-ext")))
+    if (IS_SET(restore_flags, RESTORE_SDEXT) && 0 != (ret = nandroid_restore_partition(backup_path, "/sd-ext")))
         return ret;
 
     sync();
@@ -416,7 +416,7 @@ int nandroid_main(int argc, char** argv)
     {
         if (argc != 3)
             return nandroid_usage();
-        return nandroid_restore(argv[2], 1, 1, 1, 1, 1, 0);
+        return nandroid_restore(argv[2], RESTORE_BOOT | RESTORE_SYSTEM | RESTORE_DATA | RESTORE_CACHE | RESTORE_SDEXT);
     }
     
     return nandroid_usage();

--- a/nandroid.h
+++ b/nandroid.h
@@ -3,7 +3,14 @@
 
 int nandroid_main(int argc, char** argv);
 int nandroid_backup(const char* backup_path);
-int nandroid_restore(const char* backup_path, int restore_boot, int restore_system, int restore_data, int restore_cache, int restore_sdext, int restore_wimax);
+int nandroid_restore(const char* backup_path, char restore_flags);
 void nandroid_generate_timestamp_path(char* backup_path);
+
+#define RESTORE_BOOT    (1 << 0)
+#define RESTORE_SYSTEM  (1 << 1)
+#define RESTORE_DATA    (1 << 2)
+#define RESTORE_CACHE   (1 << 3)
+#define RESTORE_SDEXT   (1 << 4)
+#define RESTORE_WIMAX   (1 << 5)
 
 #endif


### PR DESCRIPTION
This change migrates the nandroid_restore function from using positional arguments to using a single character using bits to set the restore functions.

This makes the code more readable (which in turn should lend itself to less programming error) and allow for additional partitions to be backed up without manually touching many parts of the code.
