### PR TITLE
Ensure errors are reported when checking md5sums and sdcard is full.

### DIFF
--- a/nandroid-md5.sh
+++ b/nandroid-md5.sh
@@ -1,4 +1,28 @@
 #!/sbin/sh
 cd $1
-md5sum *img > nandroid.md5
-return $?
+op=nandroid.md5
+ret=0
+rm -f ${op}
+for f in *img; do
+    md5sum ${f} >> ${op}
+    if [ ! -s ${f} ]; then
+	ret=`expr ${ret} + 1`
+    fi
+done
+if [ ! -s ${op} ]; then
+    ret=`expr ${ret} + 1`
+    echo Error: "${op}" zero length
+fi
+return ${ret}
+#
+#
+# A test for empty files in the md5 sum:
+# [ "`grep '^d41d8cd98f00b204e9800998ecf8427e' nandroid.md5 | wc -l`" -eq 0 ]
+# because d41...27e is the md5 of a zero length file (^ matches to start of line)
+# Also need to test that the nandroid.md5 is non-zero:
+# [ "`wc -l < nandroid.md5`" -gt 0 ]
+#
+# Combined:
+# [ "`wc -l < nandroid.md5`" -gt 0 -a "`grep '^d41d8cd98f00b204e9800998ecf8427e' nandroid.md5 | wc -l`" -eq 0 ]
+#
+#

--- a/nandroid.c
+++ b/nandroid.c
@@ -315,7 +315,21 @@ int nandroid_restore(const char* backup_path, int restore_boot, int restore_syst
     char tmp[PATH_MAX];
 
     ui_print("Checking MD5 sums...\n");
-    sprintf(tmp, "cd %s && md5sum -c nandroid.md5", backup_path);
+    /*
+      # A test for empty files in the md5 sum:
+      # [ "`grep '^d41d8cd98f00b204e9800998ecf8427e' nandroid.md5 | wc -l`" -eq 0 ]
+      # because d41...27e is the md5 of a zero length file (^ matches to start of line)
+      # Also need to test that the nandroid.md5 is non-zero:
+      # [ "`wc -l < nandroid.md5`" -gt 0 ]
+      #
+      # Combined:
+      # [ "`wc -l < nandroid.md5`" -gt 0 -a
+      #   "`grep '^d41d8cd98f00b204e9800998ecf8427e' nandroid.md5 | wc -l`" -eq 0 ]
+      #
+     */
+    sprintf(tmp, "cd %s && [ \"`wc -l < nandroid.md5`\" -gt 0 -a "
+	    "\"`grep '^d41d8cd98f00b204e9800998ecf8427e' nandroid.md5 |"
+	    " wc -l`\" -eq 0 ] && md5sum -c nandroid.md5", backup_path);
     if (0 != __system(tmp))
         return print_and_error("MD5 mismatch!\n");
     


### PR DESCRIPTION
When you do a backup from the recovery, md5 sums of the .img files are
created to allow confirmation of validity of backup. Backup failure is
checked by return code from nandroid-md5.sh, but the return code is just
that of md5sum.

If the SDCARD is (nearly) full, then zero length files can be created.
Zero length files have a valid md5sum: there is no error to report.

In these cases nandroid.md5 file will also be empty,
but there is no check on this in the nandroid-md5.sh script,
nor in the code used to check validity of the md5sums
(where md5sum -c nandroid.md5 is executed and returns no error).

I've not tested these on an android phone, but the script and the one line
shell command in nandroid.c have been tested on a Linux box where
sets of backup files (good and bad) had been copied.

Change-Id: Icc14fa32608832f7fc53c1235709fdee718ef0d5
