### PR TITLE
Add a download mode menu item for Samsung devices.

### DIFF
--- a/default_recovery_ui.c
+++ b/default_recovery_ui.c
@@ -30,6 +30,9 @@ char* MENU_ITEMS[] = { "reboot system now",
                        "backup and restore",
                        "mounts and storage",
                        "advanced",
+#ifdef BOARD_IS_SAMSUNG
+					   "download mode",
+#endif					   
                        "power off",
                        NULL };
 

--- a/recovery.c
+++ b/recovery.c
@@ -753,6 +753,11 @@ prompt_and_wait() {
             case ITEM_ADVANCED:
                 show_advanced_menu();
                 break;
+#ifdef BOARD_IS_SAMSUNG            
+            case ITEM_DOWNLOAD:
+                __system("/sbin/reboot download");
+                break;
+#endif                
             case ITEM_POWEROFF:
                 poweroff=1;
                 return;


### PR DESCRIPTION
Adds "Download Mode" to the main menu, if BOARD_IS_SAMSUNG is defined.
