### PR TITLE
fix nandroid restore/backup to work as standalone executable

### DIFF
--- a/nandroid.c
+++ b/nandroid.c
@@ -599,7 +599,11 @@ int nandroid_main(int argc, char** argv)
 {
     if (argc > 3 || argc < 2)
         return nandroid_usage();
-    
+
+    // we're being called outside of recovery context
+    // need to load voume table for non-gui context:
+    load_volume_table();
+
     if (strcmp("backup", argv[1]) == 0)
     {
         if (argc != 2)


### PR DESCRIPTION
- the old nandroid_main wasn't calling load_volume_table()
- this meant that calls to ensure_path_mounted would fail since as a standalone
  binary, nandroid would not load these tables into memory.
- this patch has been tested on a nexus s phone.
