### PR TITLE
added an exclude-tag-all=.nobackup to the tar command when backing up. 

### DIFF
--- a/nandroid.c
+++ b/nandroid.c
@@ -109,7 +109,7 @@ static int mkyaffs2image_wrapper(const char* backup_path, const char* backup_fil
 static int tar_compress_wrapper(const char* backup_path, const char* backup_file_image, int callback) {
     char tmp[PATH_MAX];
     if (strcmp(backup_path, "/data") == 0 && volume_for_path("/sdcard") == NULL)
-      sprintf(tmp, "cd $(dirname %s) ; tar cvf %s.tar --exclude 'media' $(basename %s) ; exit $?", backup_path, backup_file_image, backup_path);
+      sprintf(tmp, "cd $(dirname %s) ; tar cvf %s.tar --exclude-tag='.nobackup' --exclude 'media' $(basename %s) ; exit $?", backup_path, backup_file_image, backup_path);
     else
       sprintf(tmp, "cd $(dirname %s) ; tar cvf %s.tar $(basename %s) ; exit $?", backup_path, backup_file_image, backup_path);
 


### PR DESCRIPTION
Avoid backing up large non critical data.
