### PR TITLE
Update wipe data to recognize .one_confirm or .no_confirm files in the clockworkmod folder.

### DIFF
--- a/extendedcommands.c
+++ b/extendedcommands.c
@@ -408,8 +408,12 @@ void show_mount_usb_storage_menu()
 int confirm_selection(const char* title, const char* confirm)
 {
     struct stat info;
+    ensure_path_mounted("/sdcard");
     if (0 == stat("/sdcard/clockworkmod/.no_confirm", &info))
+	{
+		ensure_path_unmounted("/sdcard");
         return 1;
+	}
 
     char* confirm_headers[]  = {  title, "  THIS CAN NOT BE UNDONE.", "", NULL };
 	if (0 == stat("/sdcard/clockworkmod/.one_confirm", &info)) {
@@ -417,6 +421,7 @@ int confirm_selection(const char* title, const char* confirm)
 						confirm, //" Yes -- wipe partition",   // [1]
 						NULL };
 		int chosen_item = get_menu_selection(confirm_headers, items, 0, 0);
+		ensure_path_unmounted("/sdcard");
 		return chosen_item == 1;
 	}
 	else {
@@ -433,9 +438,10 @@ int confirm_selection(const char* title, const char* confirm)
 						"No",
 						NULL };
 		int chosen_item = get_menu_selection(confirm_headers, items, 0, 0);
+		ensure_path_unmounted("/sdcard");
 		return chosen_item == 7;
 	}
-	}
+}
 
 #define MKE2FS_BIN      "/sbin/mke2fs"
 #define TUNE2FS_BIN     "/sbin/tune2fs"

--- a/recovery.c
+++ b/recovery.c
@@ -643,6 +643,7 @@ update_directory(const char* path, const char* unmount_when_done) {
 
 static void
 wipe_data(int confirm) {
+/*  This section is no longer needed...
     if (confirm) {
         static char** title_headers = NULL;
 
@@ -672,17 +673,21 @@ wipe_data(int confirm) {
             return;
         }
     }
+*/
 
-    ui_print("\n-- Wiping data...\n");
-    device_wipe_data();
-    erase_volume("/data");
-    erase_volume("/cache");
-    if (has_datadata()) {
-        erase_volume("/datadata");
-    }
-    erase_volume("/sd-ext");
-    erase_volume("/sdcard/.android_secure");
-    ui_print("Data wipe complete.\n");
+    if (confirm_selection("Confirm delete all user data?", "Yes - Wipe all user data"))
+	{
+		ui_print("\n-- Wiping data...\n");
+		device_wipe_data();
+		erase_volume("/data");
+		erase_volume("/cache");
+		if (has_datadata()) {
+		    erase_volume("/datadata");
+		}
+		erase_volume("/sd-ext");
+		erase_volume("/sdcard/.android_secure");
+		ui_print("Data wipe complete.\n");
+	}
 }
 
 static void


### PR DESCRIPTION
This commit allows the wipe data/factory reset option to recognize the .one_confirm or .no_confirm files in the clockworkmod folder.  

This also correctly mounts the /sdcard to verify the presence of the .nomedia
or .one_confirm in certain circumstances when the /sdcard is not
automatically mounted during bootup into cwm.

Change-Id: I88c039801e621edf9e8780f70c34fb7a1f48e51c
