### PR TITLE
jellybean: simplified writing routine for trivial files and a guard for file names from shell expansion

### DIFF
--- a/extendedcommands.c
+++ b/extendedcommands.c
@@ -755,8 +755,7 @@ int format_unknown_device(const char *device, const char* path, const char *fs_t
 
     static char tmp[PATH_MAX];
     if (strcmp(path, "/data") == 0) {
-        sprintf(tmp, "cd /data ; for f in $(ls -a | grep -v ^media$); do rm -rf $f; done");
-        __system(tmp);
+        __system("cd /data ; for f in $(ls -a | grep -v '^media$'); do rm -rf \"$f\"; done");
         // if the /data/media sdcard has already been migrated for android 4.2,
         // prevent the migration from happening again by writing the .layout_version
         struct stat st;

--- a/extendedcommands.c
+++ b/extendedcommands.c
@@ -775,9 +775,8 @@ int format_unknown_device(const char *device, const char* path, const char *fs_t
         }
     }
     else {
-        sprintf(tmp, "rm -rf %s/*", path);
-        __system(tmp);
-        sprintf(tmp, "rm -rf %s/.*", path);
+        // FIXME That's an error if the `path` contains an apostrophe.
+        sprintf(tmp, "rm -rf '%s', path);
         __system(tmp);
     }
 


### PR DESCRIPTION
Writing of the trivial files (the files which are written in one operation and closed)
was a bit wasteful by using stdio (fopen/fprintf/fwrite) routines. Use of just three
syscalls (open/write/close) is entirely justified here and reduces memory use and
code size.

This particular case wont profit much from the change (the code is relatively rarely
used), but it might set a good precedent.

A change in use of __system is actually a bug fix: the old code could not handle
files names with spaces and special characters in them at all. The whole code in
the file should be re-audited with regard to proper shell quoting: its (ab)use of
shell for even trivial operations disregards even basic rules of passing strings
to shell interpreter: the variables are almost never quoted. Besides, calling up
to shell is very slow.
