### PR TITLE
Never create symlink when primary mount point is /sdcard

### DIFF
--- a/roots.c
+++ b/roots.c
@@ -477,7 +477,8 @@ int is_data_media_preserved() {
 void setup_legacy_storage_paths() {
     char* primary_path = get_primary_storage_path();
 
-    if (!is_data_media_volume_path(primary_path)) {
+    if (!is_data_media_volume_path(primary_path) &&
+            strcmp("/sdcard", primary_path) != 0) {
         rmdir("/sdcard");
         symlink(primary_path, "/sdcard");
     }


### PR DESCRIPTION
In my device, the primary_path is /sdcard and is_data_media_volume_path returns false. It's conspicuous that we should never link /sdcard to itself, which will lead to a loop and prevent /sdcard to be mounted.

With this commit, my cwm recovery works fine.
