### PR TITLE
recovery: Fix recursive rm wipe of data

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -156,15 +156,13 @@ LOCAL_C_INCLUDES += external/boringssl/include
 ifeq ($(ONE_SHOT_MAKEFILE),)
 LOCAL_ADDITIONAL_DEPENDENCIES += \
     fstools \
-    recovery_mkshrc
+    recovery_mkshrc \
+    bu_recovery \
+    toybox_recovery_links
 
 endif
 
-LOCAL_ADDITIONAL_DEPENDENCIES += \
-    bu_recovery
-
 TOYBOX_INSTLIST := $(HOST_OUT_EXECUTABLES)/toybox-instlist
-LOCAL_ADDITIONAL_DEPENDENCIES += toybox_recovery_links
 
 # Set up the static symlinks
 RECOVERY_TOOLS := \
@@ -179,7 +177,7 @@ endif
 include $(BUILD_EXECUTABLE)
 
 # Run toybox-instlist and generate the rest of the symlinks
-toybox_recovery_links: $(TOYBOX_INSTLIST) recovery
+toybox_recovery_links: $(TOYBOX_INSTLIST)
 toybox_recovery_links: TOY_LIST=$(shell $(TOYBOX_INSTLIST))
 toybox_recovery_links: TOYBOX_BINARY := $(TARGET_RECOVERY_ROOT_OUT)/sbin/toybox
 toybox_recovery_links:

--- a/Android.mk
+++ b/Android.mk
@@ -140,6 +140,10 @@ ifneq ($(BOARD_RECOVERY_BLDRMSG_OFFSET),)
     LOCAL_CFLAGS += -DBOARD_RECOVERY_BLDRMSG_OFFSET=$(BOARD_RECOVERY_BLDRMSG_OFFSET)
 endif
 
+ifeq ($(TARGET_BUILD_VARIANT),user)
+    LOCAL_CFLAGS += -DRELEASE_BUILD
+endif
+
 LOCAL_CFLAGS += -DUSE_EXT4 -DMINIVOLD
 LOCAL_C_INCLUDES += system/extras/ext4_utils system/core/fs_mgr/include external/fsck_msdos
 LOCAL_C_INCLUDES += system/vold

--- a/device.cpp
+++ b/device.cpp
@@ -39,13 +39,17 @@ struct menu_entry {
 };
 
 static const char* WIPE_MENU_NAMES[] = {
+#ifndef RELEASE_BUILD
     "System reset (keep media)",
+#endif
     "Full factory reset",
     "Wipe cache partition",
     nullptr
 };
 static const menu_entry WIPE_MENU_ENTRIES[] = {
+#ifndef RELEASE_BUILD
     { ACTION_INVOKE, { .action = Device::WIPE_DATA } },
+#endif
     { ACTION_INVOKE, { .action = Device::WIPE_FULL } },
     { ACTION_INVOKE, { .action = Device::WIPE_CACHE } },
     { ACTION_NONE, { .action = Device::NO_ACTION } }

--- a/device.h
+++ b/device.h
@@ -19,11 +19,15 @@
 
 #include "ui.h"
 
+#include <stack>
+
 #define KEY_FLAG_ABS 0x8000
+
+struct menu;
 
 class Device : public VoldWatcher {
   public:
-    Device(RecoveryUI* ui) : ui_(ui) { }
+    explicit Device(RecoveryUI* ui);
     virtual ~Device() { }
 
     // Called to obtain the UI object that should be used to display
@@ -59,18 +63,17 @@ class Device : public VoldWatcher {
     virtual int HandleMenuKey(int key, int visible);
 
     enum BuiltinAction {
-        NO_ACTION = 0,
-        REBOOT = 1,
-        APPLY_UPDATE = 2,
-        // APPLY_CACHE was 3.
-        // APPLY_ADB_SIDELOAD was 4.
-        WIPE_DATA = 5,
-        WIPE_CACHE = 6,
-        WIPE_MEDIA = 7,
-        REBOOT_BOOTLOADER = 8,
-        SHUTDOWN = 9,
-        VIEW_RECOVERY_LOGS = 10,
-        MOUNT_SYSTEM = 11,
+        NO_ACTION,
+        REBOOT,
+        APPLY_UPDATE,
+        WIPE_DATA,
+        WIPE_FULL,
+        WIPE_CACHE,
+        REBOOT_RECOVERY,
+        REBOOT_BOOTLOADER,
+        SHUTDOWN,
+        VIEW_RECOVERY_LOGS,
+        MOUNT_SYSTEM,
     };
 
     // Return the list of menu items (an array of strings,
@@ -117,6 +120,8 @@ class Device : public VoldWatcher {
 
   private:
     RecoveryUI* ui_;
+
+    std::stack<const menu*> menu_stack;
 };
 
 // The device-specific library must define this function (or the

--- a/install.cpp
+++ b/install.cpp
@@ -300,8 +300,10 @@ really_install_package(const char *path, bool* wipe_cache, bool needs_mount)
     if (path && needs_mount) {
         if (path[0] == '@') {
             ensure_path_mounted(path+1);
+            remount_no_selinux(path+1);
         } else {
             ensure_path_mounted(path);
+            remount_no_selinux(path);
         }
     }
 

--- a/recovery.cpp
+++ b/recovery.cpp
@@ -790,7 +790,7 @@ static char* browse_directory(const char* path, Device* device) {
     z_size += d_size;
     zips[z_size] = NULL;
 
-    const char* headers[] = { "Choose a package to install:", path, NULL };
+    const char* headers[] = { path, NULL };
 
     char* result;
     int chosen_item = 0;
@@ -983,7 +983,7 @@ static int apply_from_storage(Device* device, const std::string& id, bool* wipe_
 
 static int
 show_apply_update_menu(Device* device) {
-    static const char* headers[] = { "Apply update", "", NULL };
+    static const char* headers[] = { "Apply update", NULL };
     char* menu_items[MAX_NUM_MANAGED_VOLUMES + 1 + 1];
     std::vector<VolumeInfo> volumes = vdc->getVolumes();
 

--- a/recovery.cpp
+++ b/recovery.cpp
@@ -649,6 +649,11 @@ get_menu_selection(const char* const * headers, const char* const * items,
     ui->FlushKeys();
 
     // Count items to detect valid values for absolute selection
+    int header_count = 0;
+    if (headers) {
+        while (headers[header_count] != NULL)
+            ++header_count;
+    }
     int item_count = 0;
     while (items[item_count] != NULL)
         ++item_count;
@@ -679,15 +684,15 @@ get_menu_selection(const char* const * headers, const char* const * items,
         int action = device->HandleMenuKey(key, visible);
 
         if (action >= 0) {
-            if ((action & ~KEY_FLAG_ABS) >= item_count) {
+            action &= ~KEY_FLAG_ABS;
+            if (action < header_count || action >= header_count + item_count) {
                 action = Device::kNoAction;
             }
             else {
                 // Absolute selection.  Update selected item and give some
                 // feedback in the UI by selecting the item for a short time.
-                selected = action & ~KEY_FLAG_ABS;
+                selected = ui->SelectMenu(action, true);
                 action = Device::kInvokeItem;
-                selected = ui->SelectMenu(selected, true);
                 usleep(50*1000);
             }
         }

--- a/recovery.cpp
+++ b/recovery.cpp
@@ -1317,6 +1317,7 @@ main(int argc, char **argv) {
         case 'h': headless = true; break;
         case 'w': should_wipe_data = true; break;
         case 'c': should_wipe_cache = true; break;
+        case 'm': should_wipe_media = true; break;
         case 't': show_text = true; break;
         case 's': sideload = true; break;
         case 'a': sideload = true; sideload_auto_reboot = true; break;

--- a/recovery.cpp
+++ b/recovery.cpp
@@ -1025,8 +1025,6 @@ refresh:
     return status;
 }
 
-int ui_root_menu = 0;
-
 // Return REBOOT, SHUTDOWN, or REBOOT_BOOTLOADER.  Returning NO_ACTION
 // means to take the default, which is to reboot or shutdown depending
 // on if the --shutdown_after flag was passed to recovery.
@@ -1034,7 +1032,6 @@ static Device::BuiltinAction
 prompt_and_wait(Device* device, int status) {
     for (;;) {
         finish_recovery(NULL);
-        ui_root_menu = 1;
         switch (status) {
             case INSTALL_SUCCESS:
             case INSTALL_NONE:
@@ -1049,7 +1046,6 @@ prompt_and_wait(Device* device, int status) {
         ui->SetProgressType(RecoveryUI::EMPTY);
 
         int chosen_item = get_menu_selection(nullptr, device->GetMenuItems(), 0, 0, device);
-        ui_root_menu = 0;
 
         // device-specific code may take some action here.  It may
         // return one of the core actions handled in the switch
@@ -1064,6 +1060,7 @@ prompt_and_wait(Device* device, int status) {
 
                 case Device::REBOOT:
                 case Device::SHUTDOWN:
+                case Device::REBOOT_RECOVERY:
                 case Device::REBOOT_BOOTLOADER:
                     return chosen_action;
 
@@ -1072,13 +1069,13 @@ prompt_and_wait(Device* device, int status) {
                     if (!ui->IsTextVisible()) return Device::NO_ACTION;
                     break;
 
-                case Device::WIPE_CACHE:
-                    wipe_cache(ui->IsTextVisible(), device);
+                case Device::WIPE_FULL:
+                    wipe_data(ui->IsTextVisible(), device, true);
                     if (!ui->IsTextVisible()) return Device::NO_ACTION;
                     break;
 
-                case Device::WIPE_MEDIA:
-                    wipe_media(ui->IsTextVisible(), device);
+                case Device::WIPE_CACHE:
+                    wipe_cache(ui->IsTextVisible(), device);
                     if (!ui->IsTextVisible()) return Device::NO_ACTION;
                     break;
 
@@ -1514,6 +1511,11 @@ main(int argc, char **argv) {
         case Device::SHUTDOWN:
             ui->Print("Shutting down...\n");
             property_set(ANDROID_RB_PROPERTY, "shutdown,");
+            break;
+
+        case Device::REBOOT_RECOVERY:
+            ui->Print("Rebooting recovery...\n");
+            property_set(ANDROID_RB_PROPERTY, "reboot,recovery");
             break;
 
         case Device::REBOOT_BOOTLOADER:

--- a/roots.cpp
+++ b/roots.cpp
@@ -253,7 +253,7 @@ int ensure_volume_mounted(Volume* v, bool force_rw) {
     return ensure_path_mounted_at(v->mount_point, nullptr, force_rw);
 }
 
-int remount_for_wipe(const char* path) {
+int remount_no_selinux(const char* path) {
     int ret;
 
     char *old_fs_options;
@@ -406,7 +406,7 @@ int format_volume(const char* volume, bool force) {
             LOGE("format_volume failed to mount /data\n");
             return -1;
         }
-        remount_for_wipe("/data");
+        remount_no_selinux("/data");
         int rc = 0;
         rc = rmtree_except("/data/media", NULL);
         ensure_path_unmounted("/data");
@@ -430,7 +430,7 @@ int format_volume(const char* volume, bool force) {
 
     if (!force && strcmp(volume, "/data") == 0 && vdc->isEmulatedStorage()) {
         if (ensure_path_mounted("/data") == 0) {
-            remount_for_wipe("/data");
+            remount_no_selinux("/data");
             // Preserve .layout_version to avoid "nesting bug"
             LOGI("Preserving layout version\n");
             unsigned char layout_buf[256];

--- a/roots.cpp
+++ b/roots.cpp
@@ -458,7 +458,10 @@ int format_volume(const char* volume, bool force) {
 
             return rc;
         }
-        LOGE("format_volume failed to mount /data, formatting instead\n");
+        else {
+            LOGE("format_volume failed to mount /data\n");
+            return -1;
+        }
     }
 
     if (ensure_path_unmounted(volume) != 0) {

--- a/roots.cpp
+++ b/roots.cpp
@@ -253,6 +253,33 @@ int ensure_volume_mounted(Volume* v, bool force_rw) {
     return ensure_path_mounted_at(v->mount_point, nullptr, force_rw);
 }
 
+int remount_for_wipe(const char* path) {
+    int ret;
+
+    char *old_fs_options;
+    char *new_fs_options;
+
+    char se_context[] = ",context=u:object_r:app_data_file:s0";
+    Volume *v;
+
+    // Backup original mount options
+    v = volume_for_path(path);
+    old_fs_options = v->fs_options;
+
+    // Add SELinux mount override
+    asprintf(&new_fs_options, "%s%s", v->fs_options, se_context);
+    v->fs_options = new_fs_options;
+
+    ensure_path_unmounted(path);
+    ret = ensure_path_mounted(path);
+
+    // Restore original mount options
+    v->fs_options = old_fs_options;
+    free(new_fs_options);
+
+    return ret;
+}
+
 int ensure_path_mounted(const char* path, bool force_rw) {
     // Mount at the default mount point.
     return ensure_path_mounted_at(path, nullptr, force_rw);
@@ -379,6 +406,7 @@ int format_volume(const char* volume, bool force) {
             LOGE("format_volume failed to mount /data\n");
             return -1;
         }
+        remount_for_wipe("/data");
         int rc = 0;
         rc = rmtree_except("/data/media", NULL);
         ensure_path_unmounted("/data");
@@ -402,6 +430,7 @@ int format_volume(const char* volume, bool force) {
 
     if (!force && strcmp(volume, "/data") == 0 && vdc->isEmulatedStorage()) {
         if (ensure_path_mounted("/data") == 0) {
+            remount_for_wipe("/data");
             // Preserve .layout_version to avoid "nesting bug"
             LOGI("Preserving layout version\n");
             unsigned char layout_buf[256];

--- a/roots.h
+++ b/roots.h
@@ -30,6 +30,8 @@ Volume* volume_for_path(const char* path);
 // success (volume is mounted).
 int ensure_volume_mounted(Volume* v, bool force_rw=false);
 int ensure_path_mounted(const char* path, bool force_rw=false);
+// Above, plus override SELinux default context
+int remount_for_wipe(const char* path);
 
 // Similar to ensure_path_mounted, but allows one to specify the mount_point.
 int ensure_path_mounted_at(const char* path, const char* mount_point, bool force_rw=false);

--- a/roots.h
+++ b/roots.h
@@ -31,7 +31,7 @@ Volume* volume_for_path(const char* path);
 int ensure_volume_mounted(Volume* v, bool force_rw=false);
 int ensure_path_mounted(const char* path, bool force_rw=false);
 // Above, plus override SELinux default context
-int remount_for_wipe(const char* path);
+int remount_no_selinux(const char* path);
 
 // Similar to ensure_path_mounted, but allows one to specify the mount_point.
 int ensure_path_mounted_at(const char* path, const char* mount_point, bool force_rw=false);

--- a/screen_ui.h
+++ b/screen_ui.h
@@ -119,6 +119,7 @@ class ScreenRecoveryUI : public RecoveryUI {
 
     char** menu_;
     const char* const* menu_headers_;
+    int header_items;
     bool show_menu;
     int menu_items, menu_sel;
 


### PR DESCRIPTION
Android 6 re-introduced MCS/MLS SELinux contexts.  Unforunately,
this broke our previous SELinux model for walking /data and unlinking
everything but media.  Fix this by mounting /data with a temporary
SELinux context that works with the previous model.

Ticket: CYNGNOS-1747
Change-Id: Id87ad3bb357102c3a8bd7c1417183d788ef858a0
